### PR TITLE
feat: Add CHP plant handler with miner interlock

### DIFF
--- a/apps/apps.yaml
+++ b/apps/apps.yaml
@@ -19,6 +19,12 @@ energy_manager:
     activation_threshold: 2000
     max_power: 6000
     power_step: 1000
+    min_wait_time: 3
+
+  chp_handler:
+    switch_entity: switch.chp_plant # Please update this to your actual CHP switch entity
+    power_draw_threshold: 1000
+    min_wait_time: 3
 
   # Entities the controller will create/publish to
   publish_entities:
@@ -34,5 +40,8 @@ energy_manager:
     grid_export: sensor.controller_grid_export
     solar_production: sensor.controller_solar_production
     miner_consumption: sensor.controller_miner_consumption
+    miner_intended_switch_state: sensor.controller_miner_intended_switch_state
+    miner_intended_power_limit: sensor.controller_miner_intended_power_limit
+    chp_intended_switch_state: sensor.controller_chp_intended_switch_state
     controller_running: binary_sensor.controller_running
     last_successful_run: sensor.controller_last_successful_run

--- a/apps/chp_handler.py
+++ b/apps/chp_handler.py
@@ -1,0 +1,82 @@
+import appdaemon.plugins.hass.hassapi as hass
+from system_state import SystemState
+from datetime import datetime, timezone
+
+class ChpHandler:
+    """A class to contain all logic for controlling the CHP plant."""
+
+    def __init__(self, app, config):
+        """
+        Initializes the handler.
+        Args:
+            app: The AppDaemon app instance.
+            config: The configuration dictionary for this handler.
+        """
+        self.app = app
+        self.config = config
+        self.entity_id = self.config.get("switch_entity")
+        self.power_draw_threshold = self.config.get("power_draw_threshold", 1000)
+        self.min_wait_time_minutes = self.config.get("min_wait_time", 3)
+
+        # Get miner config from top-level args
+        miner_config = self.app.args.get("miner_heater", {})
+        self.miner_switch_entity = miner_config.get("switch_entity")
+        # The user requested a configurable min wait time for the miner as well.
+        self.miner_min_wait_time_minutes = miner_config.get("min_wait_time", 3)
+
+
+    def _can_toggle(self, entity_id, min_wait_minutes):
+        """Checks if an entity can be toggled based on its last_changed attribute."""
+        if not entity_id:
+            return True # Nothing to check against
+
+        last_changed_str = self.app.get_state(entity_id, attribute="last_changed")
+        if last_changed_str:
+            # Appdaemon 4.x returns a datetime object, 3.x returns a string.
+            if isinstance(last_changed_str, datetime):
+                last_changed_dt = last_changed_str
+            else:
+                last_changed_dt = datetime.fromisoformat(last_changed_str)
+
+            # Ensure the datetime is timezone-aware for comparison
+            if last_changed_dt.tzinfo is None:
+                last_changed_dt = last_changed_dt.astimezone()
+
+            now = datetime.now(timezone.utc)
+            time_since_last_change_seconds = (now - last_changed_dt).total_seconds()
+
+            if time_since_last_change_seconds < min_wait_minutes * 60:
+                self.app.log(f"Cannot toggle {entity_id}. Only {time_since_last_change_seconds:.0f}s of {min_wait_minutes*60}s elapsed.")
+                return False
+        return True
+
+    def evaluate_and_act(self, state: SystemState):
+        """
+        Main decision-making method to control the CHP.
+        """
+        chp_is_on = self.app.get_state(self.entity_id) == "on"
+        miner_is_on = self.app.get_state(self.miner_switch_entity) == "on" if self.miner_switch_entity else False
+
+        # Determine if the CHP should be on based on house consumption
+        should_be_on = state.house_consumption > self.power_draw_threshold
+
+        if should_be_on:
+            # Condition to turn on CHP is met
+            if miner_is_on:
+                # If miner is on, we must turn it off first.
+                if self._can_toggle(self.miner_switch_entity, self.miner_min_wait_time_minutes):
+                    self.app.log(f"CHP: House consumption is high ({state.house_consumption}W > {self.power_draw_threshold}W), but miner is on. Turning miner off first.")
+                    state.miner_intended_switch_state = 'off'
+                # Do not proceed to turn on CHP in this cycle. Wait for the miner to be off.
+            else:
+                # Miner is off, and we need power, so turn CHP on if it's currently off.
+                if not chp_is_on:
+                    if self._can_toggle(self.entity_id, self.min_wait_time_minutes):
+                        self.app.log(f"CHP: House consumption is high ({state.house_consumption}W > {self.power_draw_threshold}W) and miner is off. Turning CHP on.")
+                        state.chp_intended_switch_state = 'on'
+        else:
+            # Condition to turn on CHP is not met, so it should be off.
+            if chp_is_on:
+                if self._can_toggle(self.entity_id, self.min_wait_time_minutes):
+                    self.app.log(f"CHP: House consumption is low ({state.house_consumption}W <= {self.power_draw_threshold}W). Turning CHP off.")
+                    state.chp_intended_switch_state = 'off'

--- a/apps/energy_controller.py
+++ b/apps/energy_controller.py
@@ -3,6 +3,7 @@ from datetime import datetime, timezone
 from system_state import SystemState
 from miner_heater_handler import MinerHeaterHandler
 from battery_handler import BatteryHandler
+from chp_handler import ChpHandler
 
 class EnergyController(hass.Hass):
     """The main AppDaemon class for orchestrating energy devices."""
@@ -29,6 +30,11 @@ class EnergyController(hass.Hass):
             battery_config = self.args["battery_handler"]
             self.device_handlers.append(BatteryHandler(self, battery_config))
             self.log("Initialized BatteryHandler.")
+
+        if "chp_handler" in self.args:
+            chp_config = self.args["chp_handler"]
+            self.device_handlers.append(ChpHandler(self, chp_config))
+            self.log("Initialized ChpHandler.")
 
         # Add more handlers here for other devices, e.g., wallbox
 

--- a/apps/system_state.py
+++ b/apps/system_state.py
@@ -29,6 +29,7 @@ class SystemState:
     miner_intended_power_limit: Optional[float] = None
     miner_intended_switch_state: Optional[str] = None
     battery_intended_charge_switch_state: Optional[str] = None
+    chp_intended_switch_state: Optional[str] = None
 
     @classmethod
     def validate_sensors(cls, app: hass.Hass, sensors: dict) -> bool:
@@ -171,6 +172,7 @@ class SystemState:
             "miner_intended_power_limit": "miner_intended_power_limit",
             "miner_intended_switch_state": "miner_intended_switch_state",
             "battery_intended_charge_switch_state": "battery_intended_charge_switch_state",
+            "chp_intended_switch_state": "chp_intended_switch_state",
         }
 
         # Units for the sensors
@@ -225,6 +227,7 @@ class SystemState:
         """
         miner_config = app.args.get("miner_heater", {})
         battery_config = app.args.get("battery_handler", {})
+        chp_config = app.args.get("chp_handler", {})
 
         # Miner Actions
         if self.miner_intended_switch_state is not None:
@@ -269,3 +272,16 @@ class SystemState:
                             app.turn_off(entity)
                     else:
                         app.log(f"[DRY RUN] Would have turned {action} charging for {entity}")
+
+        # CHP Actions
+        if self.chp_intended_switch_state is not None:
+            entity = chp_config.get("switch_entity")
+            if entity and app.get_state(entity) != self.chp_intended_switch_state:
+                app.log(f"Intending to turn {self.chp_intended_switch_state} {entity}")
+                if not self.is_dry_run:
+                    if self.chp_intended_switch_state == 'on':
+                        app.turn_on(entity)
+                    else:
+                        app.turn_off(entity)
+                else:
+                    app.log(f"[DRY RUN] Would have turned {self.chp_intended_switch_state} {entity}")


### PR DESCRIPTION
This commit introduces a new handler for a Combined Heat and Power (CHP) plant.

Features:
- The CHP handler turns the plant on when household power consumption exceeds a configurable threshold (default: 1kW).
- The CHP will only turn on if the miner device is off. If the miner is on, it will be turned off first, and the CHP will wait for the next control cycle to turn on.
- A configurable minimum wait time (default: 3 minutes) is enforced for both the CHP and the miner to prevent rapid state changes.
- The intended states of the CHP and miner are published to Home Assistant for monitoring.

Changes:
- Created `apps/chp_handler.py` with the core logic for the CHP handler.
- Updated `apps/system_state.py` to include `chp_intended_switch_state` and the logic to execute the state change.
- Updated `apps/energy_controller.py` to load and run the new handler.
- Updated `apps/apps.yaml` with configuration for the new handler and the miner's minimum wait time.